### PR TITLE
Gpu motion correction

### DIFF
--- a/python/pipeline/utils/galvo_corrections.py
+++ b/python/pipeline/utils/galvo_corrections.py
@@ -69,6 +69,8 @@ def compute_motion_shifts(scan, template, in_place=True, num_threads=8, try_gpu=
     :param np.array template: 2-d template image. Each frame in scan is aligned to this.
     :param bool in_place: Whether the scan can be overwritten.
     :param int num_threads: Number of threads used for the ffts.
+    :param bool try_gpu: Whether to try to compute motion shifts on a GPU device. Will
+                           default to CPU computation if no GPU device is found.
 
     :returns: (y_shifts, x_shifts) Two arrays (num_frames) with the y, x motion shifts.
 

--- a/python/pipeline/utils/galvo_corrections.py
+++ b/python/pipeline/utils/galvo_corrections.py
@@ -58,7 +58,7 @@ def compute_raster_phase(image, temporal_fill_fraction):
     return angle_shift
 
 
-def compute_motion_shifts(scan, template, in_place=True, num_threads=8):
+def compute_motion_shifts(scan, template, in_place=True, num_threads=8, try_gpu=True):
     """ Compute shifts in y and x for rigid subpixel motion correction.
 
     Returns the number of pixels that each image in the scan was to the right (x_shift)
@@ -74,13 +74,16 @@ def compute_motion_shifts(scan, template, in_place=True, num_threads=8):
 
     ..note:: Based in imreg_dft.translation().
     """
-    try:
-        import cupy as cp
-        from cupy.fft import fft2, ifft2, fftshift
-        from cupy import abs
-        gpu_flag = True
-    except Exception:
-        gpu_flag = False
+    gpu_flag = False
+    if try_gpu:
+        try:
+            import cupy as cp
+            from cupy.fft import fft2, ifft2, fftshift
+            from cupy import abs
+            gpu_flag = True
+        except Exception:
+            gpu_flag = False
+    if not gpu_flag:
         import pyfftw
         from imreg_dft import utils
         from numpy.fft import fftshift


### PR DESCRIPTION
Add GPU awareness to motion correction function in galvo_corrections. Tried to maintain as much consistency with legacy CPU function as possible. Marginal additional optimizations likely possible if we were to rewrite entire function from scratch.

In simple testing, GPU-based code is about 1.5x faster than CPU-based code on 240x240 frame size.

Also added check at the top of galvo_corrections to import tukey method from the correct scipy submodule (location changed after scipy version 1.0.0)